### PR TITLE
Issue #9: set --dir to project.basedir

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -43,6 +43,7 @@ public class GaugeExecutionMojo
     extends AbstractMojo
 {
     public static final String GAUGE_EXEC_MOJO_NAME = "execute";
+    public static final String DIR_FLAG = "--dir=";
     public static final String TAGS_FLAG = "--tags";
     public static final String GAUGE = "gauge";
     public static final String PARALLEL_FLAG = "--parallel";
@@ -56,6 +57,12 @@ public class GaugeExecutionMojo
      */
     @Parameter( defaultValue = "${gauge.specs.directory}", property = "specsDir", required = false )
     private File specsDir;
+
+    /**
+     * Gauge working directory path.
+     */
+    @Parameter( defaultValue = "${project.basedir}", property = "dir", required = false )
+    private File dir;
 
     /**
      * Tags to execute. An expression eg. tag1 & tag2 & !tag3
@@ -146,6 +153,7 @@ public class GaugeExecutionMojo
         addParallelFlags(command);
         addEnv(command);
         addAdditionalFlags(command);
+        addDir(command);
         addSpecsDir(command);
         return command;
     }
@@ -170,6 +178,12 @@ public class GaugeExecutionMojo
                 command.add(NODES_FLAG);
                 command.add(Integer.toString(nodes));
             }
+        }
+    }
+
+    private void addDir(ArrayList<String> command) {
+        if (this.dir != null) {
+            command.add(DIR_FLAG + this.dir.getAbsolutePath());
         }
     }
 

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -19,6 +19,7 @@ package com.thoughtworks.gauge.maven.tests;
 
 import com.thoughtworks.gauge.maven.GaugeExecutionMojo;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -69,6 +70,35 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         assertEquals(expected, actual);
     }
 
+    public void testGetCommandWithDirSet() throws Exception
+    {
+        File testPom = new File( getBasedir(),
+                "src/test/resources/poms/dir.xml" );
+
+        GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        ArrayList<String> actual = mojo.createGaugeCommand();
+        String directory = new File("some-directory").getAbsolutePath();
+        List<String> expected = Arrays.asList(new String[]{"gauge", "--dir=" + directory, "specs"});
+        assertEquals(expected, actual);
+    }
+    
+    public void testGetCommandWithDirProjectBaseDir() throws Exception
+    {
+        File testPom = new File( getBasedir(),
+                "src/test/resources/poms/simple-config.xml" );
+      
+        MavenProject project  = new MavenProject();
+        project.setFile(testPom);
+        
+        GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupConfiguredMojo(project, GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME);
+
+        ArrayList<String> actual = mojo.createGaugeCommand();
+        String directory = testPom.getParentFile().getAbsolutePath();
+        List<String> expected = Arrays.asList(new String[]{"gauge", "--dir=" + directory, "specs"});
+        assertEquals(expected, actual);
+    }
+    
     public void testGetCommandWithParallelExecution() throws Exception
     {
         File testPom = new File( getBasedir(),

--- a/src/test/resources/poms/dir.xml
+++ b/src/test/resources/poms/dir.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <dir>some-directory</dir>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>


### PR DESCRIPTION
By default, ``--dir`` will be set to the project basedir of the Maven project.  This allows gauge to work out-of-the-box with multi-module maven projects.  Also, you can directly override this property in the pom, without having to use ``--Dflags`` or ``<flags><flag>``

Tests are added for these two cases, and both pass.