### PR TITLE
Stop using deprecated flags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -44,11 +44,11 @@ public class GaugeExecutionMojo extends AbstractMojo {
     public static final String TAGS_FLAG = "--tags";
     public static final String GAUGE = "gauge";
     public static final String RUN = "run";
-    public static final String PARALLEL_FLAG = "--parallel";
+    public static final String PARALLEL_FLAG = "-p";
     public static final String DEFAULT_SPECS_DIR = "specs";
     private static final String NODES_FLAG = "-n";
     public static final String GAUGE_CUSTOM_CLASSPATH_ENV = "gauge_custom_classpath";
-    private static final String ENV_FLAG = "--env";
+    private static final String ENV_FLAG = "-e";
 
     /**
      * Gauge spec directory path.

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -104,7 +104,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--parallel", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "-p", getPath("specs"));
         assertEquals(expected, actual);
     }
 
@@ -114,7 +114,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--tags", "tag1 & tag2 || tag3", "--parallel", "-n", "4", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--tags", "tag1 & tag2 || tag3", "-p", "-n", "4", getPath("specs"));
         assertEquals(expected, actual);
     }
 
@@ -124,7 +124,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!tag1", "--parallel", "--env", "dev", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!tag1", "-p", "-e", "dev", getPath("specs"));
         assertEquals(expected, actual);
     }
 


### PR DESCRIPTION
Ensures that the flags passed to Gauge don't trigger deprecation warnings. Will hopefully solve #19.