### PR TITLE
Fixes an issue with specsDir not generating the correct path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -187,13 +187,12 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     private void addSpecsDir(ArrayList<String> command) {
         if (this.specsDir != null) {
-            System.out.println(specsDir);
             for (String s : specsDir.split(",")) {
-                command.add(new File(s).getAbsolutePath());
+                command.add(getSpecsPath(s));
             }
         } else {
             warn("Property 'specsDir' not set. Using default value => '%s'", DEFAULT_SPECS_DIR);
-            command.add(DEFAULT_SPECS_DIR);
+            command.add(getSpecsPath(DEFAULT_SPECS_DIR));
         }
     }
 
@@ -219,4 +218,14 @@ public class GaugeExecutionMojo extends AbstractMojo {
     public String getTags() {
         return tags;
     }
+
+    /**
+     * Merges the specs path with base dir
+     * @param specsDir
+     * @return Returns absolute path joining base dir with specsDir
+     */
+    private String getSpecsPath(String specsDir) {
+        return new File(this.dir, specsDir).getAbsolutePath();
+    }
+
 }

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -59,7 +59,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!in-progress", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!in-progress", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
 
@@ -69,7 +69,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", getPath("specs/dir1"), getPath("specs/dir2"), getPath("specifications"));
+        List<String> expected = Arrays.asList("gauge", "run", getPath(getBasedir(), "specs/dir1"), getPath(getBasedir(), "specs/dir2"), getPath(getBasedir(),"specifications"));
         assertEquals(expected, actual);
     }
 
@@ -79,8 +79,8 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        String directory = getPath("some-directory");
-        List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory, "specs");
+        String directory = getPath(getBasedir(),"some-directory");
+        List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory, getPath(directory,"specs"));
         assertEquals(expected, actual);
     }
 
@@ -94,7 +94,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         ArrayList<String> actual = mojo.createGaugeCommand();
         String directory = testPom.getParentFile().getAbsolutePath();
-        List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory, "specs");
+        List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory, getPath(directory, "specs"));
         assertEquals(expected, actual);
     }
 
@@ -104,7 +104,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--parallel", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--parallel", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
 
@@ -114,7 +114,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--tags", "tag1 & tag2 || tag3", "--parallel", "-n", "4", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--tags", "tag1 & tag2 || tag3", "--parallel", "-n", "4", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
 
@@ -124,7 +124,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!tag1", "--parallel", "--env", "dev", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--tags", "!tag1", "--parallel", "--env", "dev", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
 
@@ -134,12 +134,12 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
         ArrayList<String> actual = mojo.createGaugeCommand();
-        List<String> expected = Arrays.asList("gauge", "run", "--verbose", "--log-level", "debug", getPath("specs"));
+        List<String> expected = Arrays.asList("gauge", "run", "--verbose", "--log-level", "debug", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
 
-    private String getPath(String fileName) {
-        return new File(getBasedir(), fileName).getAbsolutePath();
+    private String getPath(String baseDir, String fileName) {
+        return new File(baseDir, fileName).getAbsolutePath();
     }
 
     private File getPomFile(String fileName) {


### PR DESCRIPTION
Fixes an issue with specsDir not generating the correct path when --dir is not set to current directory.

E.g. When running `mvn -f test/functional gauge:execute` does not generate the specs dir path correctly:

**Expected**
```bash
[gauge, run, --tags, sanity, --env, docker, --verbose, --simple-console, --dir=/Users/abc12/workspace/test/functional, /Users/abc12/workspace/test/functional/specs]
```

**Actual**

``` bash
[gauge, run, --tags, sanity, --env, docker, --verbose, --simple-console, --dir=/Users/abc12/workspace/test/functional, /Users/abc12/workspace/specs]
```