### PR TITLE
Adding informations when the exception GaugeExecutionFailedException is thrown

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -102,7 +102,7 @@ public class GaugeExecutionMojo extends AbstractMojo {
         try {
             executeGaugeSpecs();
         } catch (GaugeExecutionFailedException e) {
-            throw new MojoFailureException("Gauge Specs execution failed");
+            throw new MojoFailureException("Gauge Specs execution failed. " + e.getMessage(), e);
         } catch (Exception e) {
             throw new MojoExecutionException("Error executing specs. " + e.getMessage(), e);
         }


### PR DESCRIPTION
This can help to know what's the exact error. I had this exception because the binary gauge wasn't is the PATH variable. I think it's better to have all the stacktrace.