### PR TITLE
Respect -DskipTests parameter

### DIFF
--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -132,7 +132,7 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     }
 
-    private boolean verifyParameters() {
+    public boolean verifyParameters() {
         if (isSkipTests() || isSkip()) {
             getLog().info("------------------------------------------------------------------------");
             getLog().info("Tests are skipped. ");

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeExecutionMojo.java
@@ -104,7 +104,24 @@ public class GaugeExecutionMojo extends AbstractMojo {
     @Parameter(property = "project.testClasspathElements", required = true, readonly = true)
     private List<String> classpath;
 
+    /**
+     * Set to true to skip running tests, but still compile them.
+     */
+    @Parameter(property = "skipTests", defaultValue = "false")
+    private boolean skipTests;
+
+    /**
+     * Set to true to bypass tests. If you enable "maven.test.skip" property,
+     * "maven.test.skip" property disables both running the tests and compiling the tests.
+     */
+    @Parameter(property = "maven.test.skip", defaultValue = "false")
+    private boolean skip;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!verifyParameters()) {
+            return;
+        }
+
         try {
             executeGaugeSpecs();
         } catch (GaugeExecutionFailedException e) {
@@ -113,6 +130,17 @@ public class GaugeExecutionMojo extends AbstractMojo {
             throw new MojoExecutionException("Error executing specs. " + e.getMessage(), e);
         }
 
+    }
+
+    private boolean verifyParameters() {
+        if (isSkipTests() || isSkip()) {
+            getLog().info("------------------------------------------------------------------------");
+            getLog().info("Tests are skipped. ");
+            getLog().info("------------------------------------------------------------------------");
+
+            return false;
+        }
+        return true;
     }
 
     private void executeGaugeSpecs() throws GaugeExecutionFailedException {
@@ -232,6 +260,14 @@ public class GaugeExecutionMojo extends AbstractMojo {
 
     public String getScenario() {
         return scenario;
+    }
+
+    public boolean isSkipTests() {
+        return skipTests;
+    }
+
+    public boolean isSkip() {
+        return skip;
     }
 
     /**

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -32,7 +32,6 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         super.setUp();
     }
 
-
     public void testSimpleGaugeMojo() throws Exception {
         File testPom = getPomFile("simple_config.xml");
 
@@ -41,6 +40,24 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
         assertNotNull(mojo);
         assertNull(mojo.getSpecsDir());
         assertNull(mojo.getTags());
+    }
+
+    public void testSimpleGaugeMojoWithSkipTests() throws Exception {
+        File testPom = getPomFile("skip_tests.xml");
+
+        GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        assertNotNull(mojo);
+        assertEquals(true, mojo.isSkipTests());
+    }
+
+    public void testSimpleGaugeMojoToVerifySkipTests() throws Exception {
+        File testPom = getPomFile("skip_tests.xml");
+
+        GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
+
+        boolean actual = mojo.verifyParameters();
+        assertEquals(false, actual);
     }
 
     public void testSimpleGaugeMojoWithSpecsDirAndTags() throws Exception {

--- a/src/test/resources/poms/skip_tests.xml
+++ b/src/test/resources/poms/skip_tests.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>


### PR DESCRIPTION


Defined in mojo with some parameters. These parameters map skipTests and maven.test.skip.

We can verify parameters and if not verified before execution, then we can break it.