### PR TITLE
Adds additional MOJO to validate specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the below snippet to pom.xml
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.3.0</version>
+             <version>1.4.0</version>
          </plugin>
      </plugins>
  </build>
@@ -100,7 +100,7 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
          <plugin>
              <groupId>com.thoughtworks.gauge.maven</groupId>
              <artifactId>gauge-maven-plugin</artifactId>
-             <version>1.3.0</version>
+             <version>1.4.0</version>
              <executions>
                  <execution>
                      <phase>test</phase>
@@ -118,6 +118,79 @@ Run gauge specs in project as a part of maven test phase by adding the below exe
 ```
 
 `mvn test` command will also run gauge specs if the above mentioned execution is added to the projects pom.xml
+
+### Validate specs in project
+
+Run the below command to execute all specifications in `specs` directory
+
+```bash
+mvn gauge:validate -DspecsDir=specs
+```
+
+Run the below command to validate and ignore stub implementation suggestions
+
+```
+mvn gauge:validate -Dflags="--hide-suggestion"
+```
+
+### As a part of maven test-compile phase
+
+Validate gauge specs in project as a part of maven test-compile phase by adding the below execution to yor pom.xml
+
+```
+<build>
+     <plugins>
+         <plugin>
+             <groupId>com.thoughtworks.gauge.maven</groupId>
+             <artifactId>gauge-maven-plugin</artifactId>
+             <version>1.4.0</version>
+             <executions>
+                 <execution>
+                     <phase>test-compile</phase>
+                     <configuration>
+                         <specsDir>specs</specsDir>
+                         <flags>
+                            <flag>--hide-suggestion</flag>
+                         </flags>
+                     </configuration>
+                     <goals>
+                         <goal>validate</goal>
+                     </goals>
+                 </execution>
+             </executions>
+         </plugin>
+       </plugins>
+ </build>
+```
+
+### Running both goals (validate and execute) as part of maven
+
+Add the following execution to pom.xml to run both goals:
+
+```bash
+<plugin>
+    <groupId>com.thoughtworks.gauge.maven</groupId>
+    <artifactId>gauge-maven-plugin</artifactId>
+    <version>1.4.0</version>
+    <executions>
+        <execution>
+            <id>validate</id>
+            <phase>test-compile</phase>
+            <goals>
+                <goal>validate</goal>
+            </goals>
+        </execution>
+        <execution>
+            <id>execute</id>
+            <phase>test</phase>
+            <goals><goal>execute</goal></goals>
+            <configuration>
+                <specsDir>specs</specsDir>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
 
 ### All Properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.thoughtworks.gauge.maven</groupId>
     <artifactId>gauge-maven-plugin</artifactId>
-    <version>1.3.5</version>
+    <version>1.4.0</version>
     <packaging>maven-plugin</packaging>
     <name>Gauge Maven Plugin</name>
     <url>http://github.com/getgauge/gauge-maven-plugin</url>

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeCommand.java
@@ -1,0 +1,67 @@
+package com.thoughtworks.gauge.maven;
+
+import com.thoughtworks.gauge.maven.exception.GaugeExecutionFailedException;
+import com.thoughtworks.gauge.maven.util.Util;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class GaugeCommand {
+
+    static final String DIR_FLAG = "--dir=";
+    static final String TAGS_FLAG = "--tags";
+    static final String SCENARIO_FLAG = "--scenario";
+    static final String GAUGE = "gauge";
+    static final String RUN = "run";
+    static final String VALIDATE = "validate";
+    static final String PARALLEL_FLAG = "--parallel";
+    static final String NODES_FLAG = "-n";
+    static final String GAUGE_CUSTOM_CLASSPATH_ENV = "gauge_custom_classpath";
+    static final String ENV_FLAG = "--env";
+    static final String REPEAT_FLAG = "--repeat";
+    static final String FAILED_FLAG = "--failed";
+
+    static void execute(final List<String> classpath, final List<String> command) throws GaugeExecutionFailedException {
+        try {
+            ProcessBuilder builder = createProcessBuilder(classpath, command);
+            Process process = builder.start();
+            Util.InheritIO(process.getInputStream(), System.out);
+            Util.InheritIO(process.getErrorStream(), System.err);
+            if (process.waitFor() != 0) {
+                throw new GaugeExecutionFailedException();
+            }
+        } catch (InterruptedException e) {
+            throw new GaugeExecutionFailedException(e);
+        } catch (IOException e) {
+            throw new GaugeExecutionFailedException(e);
+        }
+    }
+
+    static ProcessBuilder createProcessBuilder(final List<String> classpath, final List<String> command) {
+        ProcessBuilder builder = new ProcessBuilder();
+        builder.command(command);
+        final String customClasspath = createCustomClasspath(classpath);
+        builder.environment().put(GaugeCommand.GAUGE_CUSTOM_CLASSPATH_ENV, customClasspath);
+        return builder;
+    }
+
+    static String createCustomClasspath(final List<String> classpath) {
+        if (classpath == null || classpath.isEmpty()) {
+            return "";
+        }
+        return StringUtils.join(classpath, File.pathSeparator);
+    }
+
+    /**
+     * Merges the specs path with base dir
+     *
+     * @param specsDir
+     * @return Returns absolute path joining base dir with specsDir
+     */
+    static String getSpecsPath(final File dir, final String specsDir) {
+        return new File(dir, specsDir).getAbsolutePath();
+    }
+
+}

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
@@ -75,7 +75,6 @@ public class GaugeValidationMojo extends AbstractMojo {
         } catch (Exception e) {
             throw new MojoExecutionException("Error executing specs. " + e.getMessage(), e);
         }
-
     }
 
     public ArrayList<String> getCommand() {
@@ -89,8 +88,8 @@ public class GaugeValidationMojo extends AbstractMojo {
 
     private void addSpecsDir(ArrayList<String> command) {
         if (getSpecsDir() != null && getSpecsDir().trim().length() > 0) {
-            for (String s : specsDir.split(",")) {
-                command.add(getSpecsPath(s));
+            for (String s : getSpecsDir().split(",")) {
+                command.add(GaugeCommand.getSpecsPath(dir, s));
             }
         }
     }
@@ -105,13 +104,4 @@ public class GaugeValidationMojo extends AbstractMojo {
         return specsDir;
     }
 
-    /**
-     * Merges the specs path with base dir
-     *
-     * @param specsDir
-     * @return Returns absolute path joining base dir with specsDir
-     */
-    private String getSpecsPath(String specsDir) {
-        return new File(this.dir, specsDir).getAbsolutePath();
-    }
 }

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
@@ -1,0 +1,117 @@
+// Copyright 2015 ThoughtWorks, Inc.
+
+// This file is part of Gauge-maven-plugin.
+
+// Gauge-maven-plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Gauge-maven-plugin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Gauge-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
+
+package com.thoughtworks.gauge.maven;
+
+import com.thoughtworks.gauge.maven.exception.GaugeExecutionFailedException;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.thoughtworks.gauge.maven.GaugeCommand.GAUGE;
+import static com.thoughtworks.gauge.maven.GaugeCommand.VALIDATE;
+
+/**
+ * Goal which validates gauge specs in the project.
+ */
+
+@Mojo(name = GaugeValidationMojo.GAUGE_VALIDATION_MOJO_NAME, requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.TEST_COMPILE)
+public class GaugeValidationMojo extends AbstractMojo {
+
+    public static final String GAUGE_VALIDATION_MOJO_NAME = "validate";
+
+    /**
+     * Gauge spec directory path.
+     */
+    @Parameter(property = "specsDir", required = false)
+    private String specsDir;
+
+    /**
+     * Gauge working directory path.
+     */
+    @Parameter(defaultValue = "${project.basedir}", property = "dir", required = false, readonly = true)
+    private File dir;
+
+    /**
+     * Get Project classpath elements
+     */
+    @Parameter(property = "project.testClasspathElements", required = true, readonly = true)
+    private List<String> classpath;
+
+    /**
+     * Additional flags for gauge execution
+     */
+    @Parameter(defaultValue = "${gauge.exec.additionalFlags}", property = "flags", required = false)
+    private List flags;
+
+    /** {@inheritDoc} */
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            GaugeCommand.execute(classpath, getCommand());
+        } catch (GaugeExecutionFailedException e) {
+            throw new MojoFailureException("Gauge Specs execution failed. " + e.getMessage(), e);
+        } catch (Exception e) {
+            throw new MojoExecutionException("Error executing specs. " + e.getMessage(), e);
+        }
+
+    }
+
+    public ArrayList<String> getCommand() {
+        ArrayList<String> command = new ArrayList<String>();
+        command.add(GAUGE);
+        command.add(VALIDATE);
+        addAdditionalFlags(command);
+        addSpecsDir(command);
+        return command;
+    }
+
+    private void addSpecsDir(ArrayList<String> command) {
+        if (getSpecsDir() != null && getSpecsDir().trim().length() > 0) {
+            for (String s : specsDir.split(",")) {
+                command.add(getSpecsPath(s));
+            }
+        }
+    }
+
+    private void addAdditionalFlags(ArrayList<String> command) {
+        if (flags != null) {
+            command.addAll(flags);
+        }
+    }
+
+    public String getSpecsDir() {
+        return specsDir;
+    }
+
+    /**
+     * Merges the specs path with base dir
+     *
+     * @param specsDir
+     * @return Returns absolute path joining base dir with specsDir
+     */
+    private String getSpecsPath(String specsDir) {
+        return new File(this.dir, specsDir).getAbsolutePath();
+    }
+}

--- a/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/GaugeValidationMojo.java
@@ -1,4 +1,4 @@
-// Copyright 2015 ThoughtWorks, Inc.
+// Copyright 2018 ThoughtWorks, Inc.
 
 // This file is part of Gauge-maven-plugin.
 

--- a/src/main/java/com/thoughtworks/gauge/maven/exception/GaugeExecutionFailedException.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/exception/GaugeExecutionFailedException.java
@@ -18,6 +18,7 @@
 package com.thoughtworks.gauge.maven.exception;
 
 public class GaugeExecutionFailedException extends Exception {
+
     public GaugeExecutionFailedException(Throwable throwable) {
         super(throwable);
     }

--- a/src/main/java/com/thoughtworks/gauge/maven/util/Util.java
+++ b/src/main/java/com/thoughtworks/gauge/maven/util/Util.java
@@ -22,6 +22,7 @@ import java.io.PrintStream;
 import java.util.Scanner;
 
 public class Util {
+
     public static void InheritIO(final InputStream src, final PrintStream dest) {
         new Thread(new Runnable() {
             public void run() {

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeExecutionMojoTestCase.java
@@ -75,7 +75,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--tags", "!in-progress", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -95,7 +95,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--scenario", "scenario", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -105,7 +105,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", getPath(getBasedir(), "specs/dir1"), getPath(getBasedir(), "specs/dir2"), getPath(getBasedir(),"specifications"));
         assertEquals(expected, actual);
     }
@@ -115,7 +115,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         String directory = getPath(getBasedir(),"some-directory");
         List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory);
         assertEquals(expected, actual);
@@ -129,7 +129,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupConfiguredMojo(project, GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         String directory = testPom.getParentFile().getAbsolutePath();
         List<String> expected = Arrays.asList("gauge", "run", "--dir=" + directory);
         assertEquals(expected, actual);
@@ -140,7 +140,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--parallel", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -150,7 +150,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--tags", "tag1 & tag2 || tag3", "--parallel", "-n", "4", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -160,7 +160,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--tags", "!tag1", "--parallel", "--env", "dev", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -170,7 +170,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--verbose", "--log-level", "debug", getPath(getBasedir(), "specs"));
         assertEquals(expected, actual);
     }
@@ -180,7 +180,7 @@ public class GaugeExecutionMojoTestCase extends AbstractMojoTestCase {
 
         GaugeExecutionMojo mojo = (GaugeExecutionMojo) lookupMojo(GaugeExecutionMojo.GAUGE_EXEC_MOJO_NAME, testPom);
 
-        ArrayList<String> actual = mojo.createGaugeCommand();
+        ArrayList<String> actual = mojo.getCommand();
         List<String> expected = Arrays.asList("gauge", "run", "--repeat");
         assertEquals(expected, actual);
     }

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeValidationMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeValidationMojoTestCase.java
@@ -1,0 +1,83 @@
+// Copyright 2015 ThoughtWorks, Inc.
+
+// This file is part of Gauge-maven-plugin.
+
+// Gauge-maven-plugin is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Gauge-maven-plugin is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Gauge-maven-plugin.  If not, see <http://www.gnu.org/licenses/>.
+
+package com.thoughtworks.gauge.maven.tests;
+
+import com.thoughtworks.gauge.maven.GaugeValidationMojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class GaugeValidationMojoTestCase extends AbstractMojoTestCase {
+
+    protected void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testSimpleGaugeMojo() throws Exception {
+        File testPom = getPomFile("simple_config.xml");
+
+        GaugeValidationMojo mojo = (GaugeValidationMojo) lookupMojo(GaugeValidationMojo.GAUGE_VALIDATION_MOJO_NAME, testPom);
+
+        assertNotNull(mojo);
+        assertNull(mojo.getSpecsDir());
+    }
+
+    public void testSimpleGaugeMojoWithSpecsDir() throws Exception {
+        File testPom = getPomFile("validate_specs.xml");
+
+        GaugeValidationMojo mojo = (GaugeValidationMojo) lookupMojo(GaugeValidationMojo.GAUGE_VALIDATION_MOJO_NAME, testPom);
+
+        assertNotNull(mojo);
+        assertEquals("specs", mojo.getSpecsDir());
+
+        ArrayList<String> actual = mojo.getCommand();
+        List<String> expected = Arrays.asList("gauge", "validate", getPath(getBasedir(), "specs"));
+        assertEquals(expected, actual);
+    }
+
+    public void testGetCommandWithMultipleSpecs() throws Exception {
+        File testPom = getPomFile("multiple_specs.xml");
+
+        GaugeValidationMojo mojo = (GaugeValidationMojo) lookupMojo(GaugeValidationMojo.GAUGE_VALIDATION_MOJO_NAME, testPom);
+
+        ArrayList<String> actual = mojo.getCommand();
+        List<String> expected = Arrays.asList("gauge", "validate", getPath(getBasedir(), "specs/dir1"), getPath(getBasedir(), "specs/dir2"), getPath(getBasedir(),"specifications"));
+        assertEquals(expected, actual);
+    }
+
+    public void testGerCommandWithHideSuggestion() throws Exception {
+        File testPom = getPomFile("validate_flags.xml");
+
+        GaugeValidationMojo mojo = (GaugeValidationMojo) lookupMojo(GaugeValidationMojo.GAUGE_VALIDATION_MOJO_NAME, testPom);
+
+        ArrayList<String> actual = mojo.getCommand();
+        List<String> expected = Arrays.asList("gauge", "validate", "--hide-suggestion", getPath(getBasedir(), "specs"));
+        assertEquals(expected, actual);
+    }
+
+    private String getPath(String baseDir, String fileName) {
+        return new File(baseDir, fileName).getAbsolutePath();
+    }
+
+    private File getPomFile(String fileName) {
+        return new File(getBasedir(), "src/test/resources/poms/" + fileName);
+    }
+}

--- a/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeValidationMojoTestCase.java
+++ b/src/test/java/com/thoughtworks/gauge/maven/tests/GaugeValidationMojoTestCase.java
@@ -1,4 +1,4 @@
-// Copyright 2015 ThoughtWorks, Inc.
+// Copyright 2018 ThoughtWorks, Inc.
 
 // This file is part of Gauge-maven-plugin.
 

--- a/src/test/resources/poms/validate_flags.xml
+++ b/src/test/resources/poms/validate_flags.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <flags>
+                        <param>--hide-suggestion</param>
+                    </flags>
+                    <specsDir>specs</specsDir>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>

--- a/src/test/resources/poms/validate_specs.xml
+++ b/src/test/resources/poms/validate_specs.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.foo</groupId>
+    <artifactId>test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.thoughtworks.gauge.maven</groupId>
+                <artifactId>gauge-maven-plugin</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <configuration>
+                    <specsDir>specs</specsDir>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>


### PR DESCRIPTION
This adds an additional phase `validate` to run, so that we can exit a build if `specs` have any validation errors.

Usage:
```xml
<plugin>
	<groupId>com.thoughtworks.gauge.maven</groupId>
	<artifactId>gauge-maven-plugin</artifactId>
	<version>1.4.0</version>
	<executions>
		<execution>
			<goals>
				<goal>validate</goal>
			</goals>
		</execution>
	</executions>
	<configuration>
		<flags>
			<flag>--hide-suggestion</flag>
		</flags>
		<specsDir>specs</specsDir>
	</configuration>
</plugin>
```